### PR TITLE
Feat/dmenu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "HyprBind"
-version = "0.1.4"
+version = "0.1.4-alpha"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "HyprBind"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "HyprBind"
-version = "0.1.4"
+version = "0.1.4-alpha"
 edition = "2024"
 license = "MIT AND OFL-1.1"
 authors = ["Ry2X <45420571+ry2x@users.noreply.github.com>"]
@@ -12,16 +12,16 @@ categories = ["gui", "visualization"]
 
 [dependencies]
 eframe = { version = "0.33.0", default-features = false, features = [
-    "glow",
-    "wayland",
-    "x11",
+  "glow",
+  "wayland",
+  "x11",
 ] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui = { version = "0.33.0", default-features = false }
 egui_extras = { version = "0.33.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.149", default-features = false, features = [
-    "std",
+  "std",
 ] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "HyprBind"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT AND OFL-1.1"
 authors = ["Ry2X <45420571+ry2x@users.noreply.github.com>"]

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname='hyprbind'
 _pkgname='HyprBind'
-pkgver='0.1.4-alpha'
+pkgver='0.1.4_alpha'
 pkgrel=1
 pkgdesc='A GUI to display Hyprland keybindings'
 arch=('x86_64' 'aarch64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname='hyprbind'
 _pkgname='HyprBind'
-pkgver='0.1.4'
+pkgver='0.1.4-alpha'
 pkgrel=1
 pkgdesc='A GUI to display Hyprland keybindings'
 arch=('x86_64' 'aarch64')
@@ -15,25 +15,25 @@ source=("$pkgname::git+file://$PWD")
 sha256sums=('SKIP')
 
 prepare() {
-    cd "$pkgname"
-    export CARGO_HOME="$srcdir/cargo-home"
-    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+  cd "$pkgname"
+  export CARGO_HOME="$srcdir/cargo-home"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-    cd "$pkgname"
-    export CARGO_HOME="$srcdir/cargo-home"
-    CARGO_TARGET_DIR=target cargo build --release --locked --offline
+  cd "$pkgname"
+  export CARGO_HOME="$srcdir/cargo-home"
+  CARGO_TARGET_DIR=target cargo build --release --locked --offline
 }
 
 package() {
-    cd "$pkgname"
-    
-    install -Dm755 "target/release/$_pkgname" "$pkgdir/usr/bin/$pkgname"
-    
-    install -Dm644 "assets/logo_hyprbind.png" "$pkgdir/usr/share/pixmaps/$pkgname.png"
-    install -Dm644 "hyprbind.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"
-    
-    install -Dm644 "LICENSE-MIT" "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
-    install -Dm644 "LICENSE-OFL" "$pkgdir/usr/share/licenses/$pkgname/LICENSE-OFL-1.1"
+  cd "$pkgname"
+
+  install -Dm755 "target/release/$_pkgname" "$pkgdir/usr/bin/$pkgname"
+
+  install -Dm644 "assets/logo_hyprbind.png" "$pkgdir/usr/share/pixmaps/$pkgname.png"
+  install -Dm644 "hyprbind.desktop" "$pkgdir/usr/share/applications/$pkgname.desktop"
+
+  install -Dm644 "LICENSE-MIT" "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
+  install -Dm644 "LICENSE-OFL" "$pkgdir/usr/share/licenses/$pkgname/LICENSE-OFL-1.1"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname='hyprbind'
 _pkgname='HyprBind'
-pkgver='0.1.3'
+pkgver='0.1.4'
 pkgrel=1
 pkgdesc='A GUI to display Hyprland keybindings'
 arch=('x86_64' 'aarch64')

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ bind = SUPER, F, exec, thunar  # description is empty
   hyprbind --json
   ```
 
+## dmenu output
+
+- Print keybinds in dmenu-compatible format and exit:
+
+  ```bash
+  cargo run -- --dmenu
+  ```
+
+  - or after installing:
+
+  ```bash
+  hyprbind --dmenu
+  ```
+
+  - Usage with dmenu:
+
+  ```bash
+  hyprbind --dmenu | dmenu -l 20
+  ```
+
 ## Config
 
 - Config file: `$XDG_CONFIG_HOME/hyprbind/config.json` (fallback: `~/.config/hyprbind/config.json`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,18 @@ fn main() -> Result<(), eframe::Error> {
             }
         }
     }
+    if args.iter().any(|a| a == "--dmenu" || a == "-d") {
+        match parser::parse_hyprctl_binds() {
+            Ok(kb) => {
+                println!("{}", kb.to_dmenu());
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("Failed to load keybindings: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
 
     let icon_data = load_icon();
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use crate::icons::get_icon;
 use serde::{Deserialize, Serialize};
 
 /// Options for searching keybindings
@@ -88,6 +89,33 @@ impl KeyBindings {
     /// Export as JSON
     pub fn to_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string_pretty(self)
+    }
+
+    /// Export as dmenu-compatible format with NERD FONT icons
+    pub fn to_dmenu(&self) -> String {
+        self.entries
+            .iter()
+            .map(|entry| {
+                let keybind = if entry.modifiers.is_empty() {
+                    get_icon(&entry.key)
+                } else {
+                    let modifiers: Vec<&str> = entry.modifiers.split('+').collect();
+                    let modifier_icons: Vec<String> =
+                        modifiers.iter().map(|m| get_icon(m)).collect();
+                    let key_icon = get_icon(&entry.key);
+                    format!("{} + {}", modifier_icons.join(" + "), key_icon)
+                };
+
+                let display_text = if !entry.description.is_empty() {
+                    entry.description.clone()
+                } else {
+                    entry.command.clone()
+                };
+
+                format!("{} :{}", keybind, display_text)
+            })
+            .collect::<Vec<String>>()
+            .join("\n")
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -101,7 +101,7 @@ impl KeyBindings {
                 } else {
                     let modifiers: Vec<&str> = entry.modifiers.split('+').collect();
                     let modifier_icons: Vec<String> =
-                        modifiers.iter().map(|m| get_icon(m)).collect();
+                        modifiers.iter().map(|m| get_icon(m.trim())).collect();
                     let key_icon = get_icon(&entry.key);
                     format!("{} + {}", modifier_icons.join(" + "), key_icon)
                 };

--- a/src/models.rs
+++ b/src/models.rs
@@ -172,18 +172,16 @@ mod tests {
         let dmenu = kb.to_dmenu();
         let lines: Vec<&str> = dmenu.lines().collect();
 
-        println!("Dmenu Output:\n{}", dmenu);
-
         // 1. No modifier, icon only
-        assert!(lines[0] == "󰌑 : Terminal");
+        assert_eq!(lines[0], "󰌑 : Terminal");
 
         // 2. Modifiers, icons
-        assert!(lines[1] == " +  󰘶  + Q : Kill window");
+        assert_eq!(lines[1], " +  󰘶  + Q : Kill window");
 
         // 3. Modifiers, fallback to key text if not in icon table
-        assert!(lines[2] == "CTRL + ALT + F1 : exec firefox");
+        assert_eq!(lines[2], "CTRL + ALT + F1 : exec firefox");
 
         // 4. Modifiers, no description, no command
-        assert!(lines[3] == "CTRL + ALT + F2 : ");
+        assert_eq!(lines[3], "CTRL + ALT + F2 : ");
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -124,3 +124,52 @@ impl Default for KeyBindings {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_dmenu() {
+        // 1. No modifier, with description
+        let entry1 = KeyBindEntry::new(
+            "".to_string(),
+            "Return".to_string(),
+            "exec kitty".to_string(),
+            "Terminal".to_string(),
+        );
+        // 2. With modifiers, with description
+        let entry2 = KeyBindEntry::new(
+            "SUPER+SHIFT".to_string(),
+            "Q".to_string(),
+            "killactive".to_string(),
+            "Kill window".to_string(),
+        );
+        // 3. With modifiers, no description
+        let entry3 = KeyBindEntry::new(
+            "CTRL+ALT".to_string(),
+            "F1".to_string(),
+            "exec firefox".to_string(),
+            "".to_string(),
+        );
+
+        let kb = KeyBindings {
+            entries: vec![entry1, entry2, entry3],
+        };
+
+        let dmenu = kb.to_dmenu();
+        let lines: Vec<&str> = dmenu.lines().collect();
+        // 1. No modifier, icon only
+        assert!(lines[0].contains("󰌑")); // Return icon
+        assert!(lines[0].contains(":Terminal"));
+        // 2. Modifiers, icons
+        assert!(lines[1].contains("")); // SUPER icon
+        assert!(lines[1].contains("󰘶")); // SHIFT icon
+        assert!(lines[1].contains(":Kill window"));
+        // 3. Modifiers, fallback to key text if not in icon table
+        assert!(lines[2].contains("CTRL"));
+        assert!(lines[2].contains("ALT"));
+        assert!(lines[2].contains("F1"));
+        assert!(lines[2].contains(":exec firefox"));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to export keybindings in a dmenu-compatible format, updates documentation accordingly, and bumps the package version to a pre-release. The main focus is on improving interoperability with dmenu and enhancing user experience with icon support.

**New dmenu export feature:**

* Added a `--dmenu` (`-d`) command-line flag to output keybindings in a dmenu-compatible format, including NERD FONT icons for modifiers and keys. This is implemented in the `main` function (`src/main.rs`) and via the new `to_dmenu` method in the `KeyBindings` model (`src/models.rs`). [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR62-R73) [[2]](diffhunk://#diff-623892a814b2aa624c59933bec54e6f0a8d9af2aea2c395f4b83418de364a3afR93-R119)
* Updated the `README.md` with instructions and usage examples for the new dmenu output feature.

**Versioning and packaging:**

* Bumped the package version to `0.1.4-alpha` in `Cargo.toml` and `0.1.4_alpha` in the Arch `PKGBUILD` to reflect the new pre-release state. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-c13dbcca92f9ff12cd26ecce958be3f9ee8563baace04f7a463a6d2dd4252e0bL5-R5)